### PR TITLE
Add !code command 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,6 +775,7 @@ dependencies = [
 name = "twitch_queue_bot"
 version = "0.1.0"
 dependencies = [
+ "tempfile",
  "tokio",
  "twitch-irc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2018"
 [dependencies]
 twitch-irc = "2.1.0"
 tokio = { version = "1.1.0", features = ["full"] }
+tempfile = "3"

--- a/chat_code.rs
+++ b/chat_code.rs
@@ -1,9 +1,8 @@
-fn format_code(message: &str) {
-    println!("{}", message);
-    let path = "scrap.rs";
+fn save_code_format(message: &str) {
+    let path = "chat_code.rs";
     let _ = File::create(path);
     fs::write(path, message).expect("Unable to write");
     let mut tidy = Command::new("rustfmt");
-    tidy.arg("scrap.rs");
+    tidy.arg(path);
     tidy.status().expect("not working");
 }

--- a/scrap.rs
+++ b/scrap.rs
@@ -1,0 +1,9 @@
+fn format_code(message: &str) {
+    println!("{}", message);
+    let path = "scrap.rs";
+    let _ = File::create(path);
+    fs::write(path, message).expect("Unable to write");
+    let mut tidy = Command::new("rustfmt");
+    tidy.arg("scrap.rs");
+    tidy.status().expect("not working");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,9 @@
-use twitch_irc::login::StaticLoginCredentials;
+
+use std::fs;
+use std::str;
+use std::fs::File;
+use std::io::prelude::*;
+use std::process::{Command, Stdio};use twitch_irc::login::StaticLoginCredentials;
 use twitch_irc::ClientConfig;
 use twitch_irc::TCPTransport;
 use twitch_irc::TwitchIRCClient;
@@ -6,6 +11,7 @@ use twitch_irc::message::{IRCMessage,PrivmsgMessage, ServerMessage};
 
 fn parse_command(msg: PrivmsgMessage) {
     let first_word = msg.message_text.split_whitespace().next();
+    let content = msg.message_text.replace(first_word.as_deref().unwrap(), "");
     match first_word {
         Some("!join") => println!("{}: Join requested", msg.sender.login),
         Some("!Pythonsucks")=> println!("{}: This must be Lord", msg.sender.login),
@@ -15,8 +21,21 @@ fn parse_command(msg: PrivmsgMessage) {
         Some("!Bazylia") => println!("{}", include_str!("../assets/bazylia.txt")),    
         Some("!Zoya") => println!("{}", include_str!("../assets/zoya.txt")),
         Some("!Discord") => println!("https://discord.gg/UyrsFX7N"),
+        Some("!code") =>  format_code(&content),
         _ => {},
     }
+}
+
+
+// Takes code after !code and writes into scrap.rs then formats with fmt - requires rustfmt installed (apt-get)
+fn format_code(message:&str) {
+    let path = "scrap.rs";
+    let _ = File::create(path);
+    fs::write(path, message).expect("Unable to write");
+    let mut tidy = Command::new("rustfmt");
+    tidy.arg("scrap.rs");
+    tidy.status().expect("not working");
+  
 }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,43 +1,55 @@
-
 use std::fs;
-use std::str;
 use std::fs::File;
 use std::io::prelude::*;
-use std::process::{Command, Stdio};use twitch_irc::login::StaticLoginCredentials;
+use std::io::{BufRead, BufReader, Error, Read, Seek, SeekFrom, Write};
+use std::process::{Command, Stdio};
+use std::str;
+use tempfile::tempdir;
+use twitch_irc::login::StaticLoginCredentials;
+use twitch_irc::message::{IRCMessage, PrivmsgMessage, ServerMessage};
 use twitch_irc::ClientConfig;
 use twitch_irc::TCPTransport;
 use twitch_irc::TwitchIRCClient;
-use twitch_irc::message::{IRCMessage,PrivmsgMessage, ServerMessage};
 
 fn parse_command(msg: PrivmsgMessage) {
     let first_word = msg.message_text.split_whitespace().next();
     let content = msg.message_text.replace(first_word.as_deref().unwrap(), "");
     match first_word {
         Some("!join") => println!("{}: Join requested", msg.sender.login),
-        Some("!Pythonsucks")=> println!("{}: This must be Lord", msg.sender.login),
-        Some("!Stonk")=> println!("{}: yOu shOULd Buy AMC sTOnKS", msg.sender.login),
-        Some("!C++")=> println!("{}: segmentation fault", msg.sender.login),
-        Some("!Dave")=> println!("{}", include_str!("../assets/dave.txt")),
-        Some("!Bazylia") => println!("{}", include_str!("../assets/bazylia.txt")),    
+        Some("!Pythonsucks") => println!("{}: This must be Lord", msg.sender.login),
+        Some("!Stonk") => println!("{}: yOu shOULd Buy AMC sTOnKS", msg.sender.login),
+        Some("!C++") => println!("{}: segmentation fault", msg.sender.login),
+        Some("!Dave") => println!("{}", include_str!("../assets/dave.txt")),
+        Some("!Bazylia") => println!("{}", include_str!("../assets/bazylia.txt")),
         Some("!Zoya") => println!("{}", include_str!("../assets/zoya.txt")),
         Some("!Discord") => println!("https://discord.gg/UyrsFX7N"),
-        Some("!code") =>  format_code(&content),
-        _ => {},
+        Some("!code") => save_code_format(&content),
+        _ => {}
     }
 }
 
+fn temp_code_format(message: &str) {
+    println!("{}", message);
+    let dir = tempdir().unwrap();
+    let mut file_path = dir.path().join("chat_code.rs");
+    let path = File::create(&file_path);
+    println!("{}", file_path.display());
+    let _ = fs::write(&file_path, message).expect("Unable to write");
+    let mut tidy = Command::new("rustfmt");
+    tidy.arg(&file_path);
+    tidy.status().expect("not working");
+    let content = fs::read_to_string(&file_path).expect("error reading file");
+    println!("{}", &content);
+}
 
-// Takes code after !code and writes into scrap.rs then formats with fmt - requires rustfmt installed (apt-get)
-fn format_code(message:&str) {
-    let path = "scrap.rs";
+fn save_code_format(message: &str) {
+    let path = "chat_code.rs";
     let _ = File::create(path);
     fs::write(path, message).expect("Unable to write");
     let mut tidy = Command::new("rustfmt");
-    tidy.arg("scrap.rs");
+    tidy.arg(path);
     tidy.status().expect("not working");
-  
 }
-
 
 #[tokio::main]
 pub async fn main() {


### PR DESCRIPTION
This feature enables twitch chatters to copy and paste code directly into chat. 

The code overwrites a scrap.rs file and then fmt is called to format it correctly. 

rustfmt is required to run `sudo apt-get install rustfmt`
`edition = "2018"` also needs to be added to the cargo.toml file

