### PR TITLE
bunch of small improvements and restructuring of command parsing/handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 [dependencies]
 async-trait = "0.1.42"
 chrono = "0.4"
-clap = "2.33.3"
 log = "0.4.14"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ toml = "0.4.2"
 twitch-irc = { version = "2.1.0", features = ["refreshing-token"] }
 
 [dev-dependencies]
-random-string = "0.1.2"
+rand = "0.8.3"

--- a/src/discord_commands.rs
+++ b/src/discord_commands.rs
@@ -233,7 +233,7 @@ fn _dispatch_error_no_macro<'fut>(
     .boxed()
 }
 
-pub async fn init_discord_bot(http: Arc<Http>, token: &str) {
+pub async fn init_discord_bot(http: &Http, token: &str) {
     // We will fetch your bot's owners and id
     let (owners, bot_id) = match http.get_current_application_info().await {
         Ok(info) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -172,7 +172,7 @@ pub async fn main() {
     let (mut incoming_messages, twitch_client) =
         TwitchIRCClient::<TCPTransport, _>::new(irc_config);
 
-    let mut context = Context {
+    let context = Context {
         queue_manager: Arc::new(Mutex::new(QueueManager::new())),
         twitch_client,
         discord_http,
@@ -198,7 +198,7 @@ pub async fn main() {
             match message {
                 ServerMessage::Privmsg(msg) => {
                     if let Some(cmd) = TwitchCommand::parse_msg(&msg) {
-                        cmd.handle(msg, &config, &mut context).await;
+                        cmd.handle(msg, &config, &context).await;
                     }
                 }
                 _ => continue,
@@ -228,7 +228,7 @@ enum TwitchCommand {
 }
 
 impl TwitchCommand {
-    async fn handle(self, msg: PrivmsgMessage, config: &FerrisBotConfig, ctx: &mut Context) {
+    async fn handle(self, msg: PrivmsgMessage, config: &FerrisBotConfig, ctx: &Context) {
         match self {
             TwitchCommand::Join => {
                 ctx.twitch_client
@@ -262,7 +262,10 @@ impl TwitchCommand {
 
             TwitchCommand::ReplyWith(reply) => {
                 ctx.twitch_client
-                    .say(msg.channel_login, format!("@{}: {}", msg.sender.login, reply))
+                    .say(
+                        msg.channel_login,
+                        format!("@{}: {}", msg.sender.login, reply),
+                    )
                     .await
                     .unwrap();
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -300,23 +300,24 @@ impl TwitchCommand {
             return None;
         }
 
-        let args: Vec<&str> = msg.message_text.split_whitespace().collect();
+        let parts: Vec<&str> = msg.message_text.split_whitespace().collect();
+        let (cmd, args) = parts.split_first()?;
 
-        match args.as_slice() {
-            ["!join", ..] => Some(TwitchCommand::Join),
-            ["!queue", ..] => Some(TwitchCommand::Queue),
-            ["!pythonsucks", ..] => Some(TwitchCommand::ReplyWith("This must be Lord")),
-            ["!stonk", ..] => Some(TwitchCommand::ReplyWith("yOu shOULd Buy AMC sTOnKS")),
-            ["!c++", ..] => Some(TwitchCommand::ReplyWith("segmentation fault")),
-            ["!dave", ..] => Some(TwitchCommand::Broadcast(include_str!("../assets/dave.txt"))),
-            ["!bazylia", ..] => Some(TwitchCommand::Broadcast(include_str!(
+        match (cmd.to_lowercase().as_str(), args) {
+            ("!join", _) => Some(TwitchCommand::Join),
+            ("!queue", _) => Some(TwitchCommand::Queue),
+            ("!pythonsucks", _) => Some(TwitchCommand::ReplyWith("This must be Lord")),
+            ("!stonk", _) => Some(TwitchCommand::ReplyWith("yOu shOULd Buy AMC sTOnKS")),
+            ("!c++", _) => Some(TwitchCommand::ReplyWith("segmentation fault")),
+            ("!dave", _) => Some(TwitchCommand::Broadcast(include_str!("../assets/dave.txt"))),
+            ("!bazylia", _) => Some(TwitchCommand::Broadcast(include_str!(
                 "../assets/bazylia.txt"
             ))),
-            ["!zoya", ..] => Some(TwitchCommand::Broadcast(include_str!("../assets/zoya.txt"))),
-            ["!discord", ..] => Some(TwitchCommand::Broadcast("https://discord.gg/UyrsFX7N")),
-            ["!nothing", ..] => Some(TwitchCommand::Nothing),
-            ["!code", ..] => Some(TwitchCommand::DiscordSnippet(
-                msg.message_text.trim_start_matches("!code ").into(),
+            ("!zoya", _) => Some(TwitchCommand::Broadcast(include_str!("../assets/zoya.txt"))),
+            ("!discord", _) => Some(TwitchCommand::Broadcast("https://discord.gg/UyrsFX7N")),
+            ("!nothing", _) => Some(TwitchCommand::Nothing),
+            ("!code", _) => Some(TwitchCommand::DiscordSnippet(
+                msg.message_text.trim_start_matches(cmd).trim_start().into(),
             )),
             _ => None,
         }
@@ -354,9 +355,15 @@ mod tests {
             TwitchCommand::parse_msg(&test_msg("!join")),
             Some(TwitchCommand::Join)
         );
+
+        // commands should be case-insensitive with their arguments left untouched
         assert_eq!(
-            TwitchCommand::parse_msg(&test_msg("!code snippet")),
-            Some(TwitchCommand::DiscordSnippet("snippet".into()))
+            TwitchCommand::parse_msg(&test_msg("!sToNk")),
+            Some(TwitchCommand::ReplyWith("yOu shOULd Buy AMC sTOnKS"))
+        );
+        assert_eq!(
+            TwitchCommand::parse_msg(&test_msg("!cOdE fn main() {}")),
+            Some(TwitchCommand::DiscordSnippet("fn main() {}".into()))
         );
     }
 

--- a/src/queue_manager.rs
+++ b/src/queue_manager.rs
@@ -23,11 +23,14 @@ impl QueueManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use random_string::{Charset, Charsets, RandomString};
+    use rand::{thread_rng, Rng, distributions::Alphanumeric};
     fn gen_random_user() -> String {
-        let charset = Charset::from_charsets(Charsets::Numbers);
-        let data = RandomString::generate(6, &charset);
-        data.to_string()
+        let rng = thread_rng();
+
+        rng.sample_iter(Alphanumeric)
+            .take(6)
+            .map(char::from)
+            .collect()
     }
 
     #[test]


### PR DESCRIPTION
**Smaller changes:**
 - removing unnecessary Arcs since most of those twitch/discord library types already have them inside
 - using LevelFilter directly since it already impls FromStr which StructOpt uses for parsing cli args
 - using rustfmt without temporary file by piping input/output (its still blocking and could probably be further improved by using async IO)
 - using rand instead of random-string since its more prominent and universal library

**Restructuring of command handling** 
I split command parsing and command handling with some abstraction for similar commands. I also put all requires services into a Context struct to be easily accesible and provided access to Config reference to use in handlers. 

I left the auth code almost untouched since I couldn't find my Twitch client ID to test any potencional changes.