### PR TITLE
Use twitch_oauth2 logic in the auth flow

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "twitch_api2"]
+	path = twitch_api2
+	url = https://github.com/Emilgardis/twitch_api2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,18 +10,18 @@ chrono = "0.4"
 futures = "0.3"
 itertools = "0.10.0"
 log = "0.4.14"
-oauth2 = "3.0.0"
-reqwest = "0.11"
+oauth2 = "4.0.0-alpha"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 simple_logger = "1.11.0"
 structopt = "0.3.13"
+surf = "2.2"
 tiny_http = "0.6"
 tokio = { version = "1", features = ["full"] }
 toml = "0.4.2"
-twitch_api2 = { version = "0.5.0-alpha", features = ["allow_unknown_fields", "client", "helix", "reqwest_client"] }
+twitch_api2 = { version = "0.5.0-alpha", features = ["client", "helix", "surf_client"], path="twitch_api2/" }
 twitch-irc = { version = "2.2.0", features = ["refreshing-token"] }
-twitch_oauth2 = "0.5.0-alpha"
+twitch_oauth2 = { version = "0.5.0-alpha", features = ["surf_client"], path = "twitch_api2/twitch_oauth2/" }
 url = "2.2.0"
 
 [dev-dependencies]

--- a/src/token_storage.rs
+++ b/src/token_storage.rs
@@ -1,0 +1,150 @@
+use async_trait::async_trait;
+use chrono::{DateTime, Duration, Utc};
+use log::debug;
+use oauth2::ClientSecret;
+use serde::{Deserialize, Serialize};
+use std::fs::File;
+use std::{fs, str};
+use twitch_irc::login::TokenStorage;
+use twitch_oauth2::TwitchToken;
+
+#[derive(Clone, Debug)]
+pub struct CustomTokenStorage {
+    pub token_checkpoint_file: String,
+}
+// Since twitch_oauth2::UserToken is not serializable, create our own
+// serializable struct. This struct can be converted to either
+// twitch_oauth2::UserToken or twitch_irc::login::UserAccesstoken.
+#[derive(Deserialize, Serialize)]
+pub struct StoredUserToken {
+    /// The access token used to authenticate requests with
+    access_token: oauth2::AccessToken,
+    client_id: oauth2::ClientId,
+    client_secret: Option<oauth2::ClientSecret>,
+    /// Username of user associated with this token
+    login: String,
+    /// The refresh token used to extend the life of this user token
+    refresh_token: Option<oauth2::RefreshToken>,
+    /// Expiration time
+    expires_at: Option<DateTime<Utc>>,
+    scopes: Option<Vec<twitch_oauth2::Scope>>,
+}
+
+impl StoredUserToken {
+    fn from_twitch_oauth2_user_token(
+        user_token: &twitch_oauth2::UserToken,
+        client_secret: Option<oauth2::ClientSecret>,
+    ) -> StoredUserToken {
+        let expires_at = Utc::now() + Duration::from_std(user_token.expires_in()).unwrap();
+        StoredUserToken {
+            access_token: user_token.access_token.clone(),
+            client_id: user_token.client_id().clone(),
+            client_secret,
+            login: user_token.login.clone(),
+            refresh_token: user_token.refresh_token.clone(),
+            expires_at: Some(expires_at),
+            scopes: Some(user_token.scopes().to_vec()),
+        }
+    }
+
+    fn to_twitch_oauth2_user_token(&self) -> twitch_oauth2::UserToken {
+        let expires_in = match self.expires_at {
+            Some(exp) => Some(exp.signed_duration_since(Utc::now()).to_std().unwrap()),
+            None => None,
+        };
+        twitch_oauth2::UserToken::from_existing_unchecked(
+            self.access_token.clone(),
+            self.refresh_token.clone(),
+            self.client_id.clone(),
+            self.client_secret.clone(),
+            self.login.clone(),
+            self.scopes.clone(),
+            expires_in,
+        )
+    }
+
+    fn to_twitch_irc_user_token(&self) -> twitch_irc::login::UserAccessToken {
+        let refresh_token = match &self.refresh_token {
+            Some(r) => r.secret().to_owned(),
+            None => "".to_owned(),
+        };
+        twitch_irc::login::UserAccessToken {
+            access_token: self.access_token.secret().to_owned(),
+            refresh_token,
+            created_at: Utc::now(),
+            expires_at: self.expires_at,
+        }
+    }
+
+    fn update_from_twitch_irc_user_token(
+        mut self,
+        user_access_token: &twitch_irc::login::UserAccessToken,
+    ) -> Self {
+        self.access_token = oauth2::AccessToken::new(user_access_token.access_token.clone());
+        self.refresh_token = Some(oauth2::RefreshToken::new(
+            user_access_token.refresh_token.clone(),
+        ));
+        self.expires_at = user_access_token.expires_at;
+        self
+    }
+}
+
+#[async_trait]
+impl TokenStorage for CustomTokenStorage {
+    type LoadError = std::io::Error; // or some other error
+    type UpdateError = std::io::Error;
+
+    async fn load_token(&mut self) -> Result<twitch_irc::login::UserAccessToken, Self::LoadError> {
+        debug!("load_token called");
+        match self.load_stored_token() {
+            Ok(t) => Ok(t.to_twitch_irc_user_token()),
+            Err(e) => Err(e),
+        }
+    }
+
+    async fn update_token(
+        &mut self,
+        token: &twitch_irc::login::UserAccessToken,
+    ) -> Result<(), Self::UpdateError> {
+        debug!("update_token called");
+        let stored_token = self.load_stored_token()?;
+        self.write_stored_token(&stored_token.update_from_twitch_irc_user_token(token))
+    }
+}
+
+impl CustomTokenStorage {
+    pub fn write_twitch_oauth2_user_token(
+        &self,
+        token: &twitch_oauth2::UserToken,
+        client_secret: Option<ClientSecret>,
+    ) -> Result<(), std::io::Error> {
+        let stored_token = &StoredUserToken::from_twitch_oauth2_user_token(token, client_secret);
+        self.write_stored_token(stored_token)
+    }
+
+    pub fn load_twitch_oauth2_user_token(
+        &self,
+    ) -> Result<twitch_oauth2::UserToken, std::io::Error> {
+        let token = self.load_stored_token()?;
+        Ok(token.to_twitch_oauth2_user_token())
+    }
+
+    fn load_stored_token(&self) -> Result<StoredUserToken, std::io::Error> {
+        let token = fs::read_to_string(&self.token_checkpoint_file)?;
+        let token = serde_json::from_str::<StoredUserToken>(&(token)).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Failed to deserialize token",
+            )
+        })?;
+        Ok(token)
+    }
+
+    fn write_stored_token(&self, stored_token: &StoredUserToken) -> Result<(), std::io::Error> {
+        let serialized = serde_json::to_string(&stored_token).unwrap();
+        let _ = File::create(&self.token_checkpoint_file);
+        fs::write(&self.token_checkpoint_file, serialized)
+            .expect("Unable to write token to checkpoint file");
+        Ok(())
+    }
+}

--- a/src/twitch_auth.rs
+++ b/src/twitch_auth.rs
@@ -1,52 +1,60 @@
 use futures::executor::block_on;
 use log::{debug, error};
-use serde::{Deserialize, Serialize};
 use tiny_http::{Response, Server, StatusCode};
+use twitch_oauth2::{tokens::UserTokenBuilder, ClientId, ClientSecret, Scope, UserToken};
 use url::Url;
 
-// Public interface of this module.
-/// First authentication token returned by Twitch APIs.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct FirstToken {
-    pub access_token: String,
-    pub expires_in: i64,
-    pub refresh_token: String,
-}
-
 /// Twitch authentication flow.
-pub fn auth_flow(client_id: &str, client_secret: &str) -> FirstToken {
-    let hook = TwitchAuthHook::new(String::from(client_id), String::from(client_secret), 10666);
+pub fn auth_flow(client_id: &str, client_secret: &str) -> UserToken {
+    let mut hook = TwitchAuthHook::new(String::from(client_id), String::from(client_secret), 10666);
+    let (url, csrf) = hook.builder.generate_url();
     println!(
         "To obtain an authentication token, please visit\n{}",
-        hook.get_twitch_auth_url()
+        url.as_str().to_owned()
     );
-    let auth = hook.receive_auth_token().unwrap();
-    hook.obtain_first_token(auth)
+    let code = hook.receive_auth_token().unwrap();
+    let user_token = block_on(async {
+        hook.builder
+            .get_user_token(
+                twitch_oauth2::client::surf_http_client,
+                csrf.secret(),
+                &code,
+            )
+            .await
+    });
+    user_token.unwrap()
 }
 
 // Internal implementation.
 struct TwitchAuthHook {
-    client_id: String,
-    client_secret: String,
     http_server: Server,
+    builder: UserTokenBuilder,
 }
 
 impl TwitchAuthHook {
     fn new(client_id: String, client_secret: String, port: i32) -> TwitchAuthHook {
         let http_server = Server::http(format!("0.0.0.0:{}", port)).unwrap();
-        TwitchAuthHook {
-            client_id,
-            client_secret,
-            http_server,
-        }
-    }
-
-    fn get_twitch_auth_url(&self) -> String {
-        format!(
-            "https://id.twitch.tv/oauth2/authorize?client_id={}&redirect_uri=http://localhost:{}&response_type=code&scope=chat:read%20chat:edit%20channel:read:subscriptions",
-            self.client_id,
-            self.http_server.server_addr().port()
+        let redirect_url = oauth2::RedirectUrl::new(format!(
+            "http://localhost:{}",
+            http_server.server_addr().port()
+        ))
+        .unwrap();
+        let builder = UserToken::builder(
+            ClientId::new(client_id),
+            ClientSecret::new(client_secret),
+            redirect_url,
         )
+        .unwrap()
+        .force_verify(true)
+        .set_scopes(vec![
+            Scope::ChannelReadSubscriptions,
+            Scope::ChatRead,
+            Scope::ChatEdit,
+        ]);
+        TwitchAuthHook {
+            http_server,
+            builder,
+        }
     }
 
     fn receive_auth_token(&self) -> Result<String, ()> {
@@ -93,52 +101,14 @@ impl TwitchAuthHook {
             None => Err(()),
         }
     }
-
-    fn obtain_first_token(&self, auth_code: String) -> FirstToken {
-        self.obtain_first_token_impl(auth_code, "https://id.twitch.tv/oauth2/token".to_owned())
-    }
-
-    // By default, this method is called by obtain_first_token passing the
-    // Twitch authentication servers URL as `remote_http_host` parameter. For
-    // testing purposes, a different `remote_http_host` with a fake
-    // implementation can be passed.
-    fn obtain_first_token_impl(&self, auth_code: String, remote_http_host: String) -> FirstToken {
-        let url = format!("{}?code={}&client_id={}&client_secret={}&grant_type=authorization_code&redirect_uri=http://localhost:{}", &remote_http_host, &auth_code, self.client_id, self.client_secret, self.http_server.server_addr().port());
-        debug!("posting to {}", url);
-        let result = block_on(async {
-            let client = reqwest::Client::new();
-            client
-                .post(&url)
-                .send()
-                .await
-                .unwrap()
-                .text()
-                .await
-                .unwrap()
-        });
-        serde_json::from_str::<FirstToken>(&result).unwrap()
-    }
 }
 
 // Tests.
 #[cfg(test)]
 mod tests {
-    use log::trace;
-    use reqwest::StatusCode;
+    use surf::StatusCode;
 
     use super::*;
-
-    #[test]
-    fn twitch_auth_url() {
-        let client_id = "xxxxxx".to_owned();
-        let client_secret = "".to_owned();
-        let hook = TwitchAuthHook::new(client_id.clone(), client_secret.clone(), 0);
-        let expected_address = format!(
-            "https://id.twitch.tv/oauth2/authorize?client_id={}&redirect_uri=http://localhost:{}&response_type=code&scope=chat:read%20chat:edit%20channel:read:subscriptions",
-            client_id,
-            hook.http_server.server_addr().port());
-        assert_eq!(hook.get_twitch_auth_url(), expected_address);
-    }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn receive_auth_token_redirect() {
@@ -153,11 +123,11 @@ mod tests {
         let testing_driver = tokio::spawn(async move {
             let http_address = format!("http://localhost:{}", server_port);
             // make a bogus requests to ensure the server doesn't quit.
-            reqwest::get(&format!("{}/favicon.ico", http_address))
+            surf::get(&format!("{}/favicon.ico", http_address))
                 .await
                 .unwrap();
             // now the real request.
-            reqwest::get(&format!(
+            surf::get(&format!(
                 "{}/?code={}&scope=chat%3Aread+chat%3Aedit",
                 http_address, expected_auth_code_clone
             ))
@@ -166,86 +136,8 @@ mod tests {
         });
 
         let response = testing_driver.await.unwrap();
-        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::Ok);
         let received_auth_code = received_auth_code.await.unwrap();
         assert_eq!(received_auth_code, Ok(expected_auth_code.to_owned()));
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn obtain_first_token() {
-        let expected_client_id = "xxxxxx".to_owned();
-        let expected_client_secret = "yyyyyyyy".to_owned();
-        let expected_auth_code = "zzzzzzzz".to_owned();
-        let hook = TwitchAuthHook::new(
-            expected_client_id.clone(),
-            expected_client_secret.clone(),
-            0,
-        );
-        let bot_port = hook.http_server.server_addr().port();
-        let expected_first_token = FirstToken {
-            access_token: "xxxxxx".to_owned(),
-            expires_in: 123,
-            refresh_token: "yyyy".to_owned(),
-        };
-
-        // Set up and start fake twitch server.
-        let expected_first_token_clone = expected_first_token.clone();
-        let expected_auth_code_clone = expected_auth_code.clone();
-        let expected_client_id_clone = expected_client_id.clone();
-        let expected_client_secret_clone = expected_client_secret.clone();
-        let http_server = Server::http("0.0.0.0:0").unwrap();
-        let server_port = http_server.server_addr().port();
-        tokio::spawn(async move {
-            match http_server.recv() {
-                Ok(rq) => {
-                    assert_eq!(rq.method(), &tiny_http::Method::Post);
-
-                    let url = format!(
-                        "http://localhost:{}{}",
-                        http_server.server_addr().port(),
-                        rq.url()
-                    );
-                    let url = Url::parse(&url).unwrap();
-                    let pairs = url.query_pairs();
-                    let mut actual_code: Option<String> = None;
-                    let mut actual_client_id: Option<String> = None;
-                    let mut actual_client_secret: Option<String> = None;
-                    let mut actual_redirect_uri: Option<String> = None;
-                    let mut actual_grant_type: Option<String> = None;
-                    for (key, value) in pairs {
-                        trace!("parsing keys {} = {}", key, value);
-                        match &*key {
-                            "code" => actual_code = Some(value.into_owned()),
-                            "client_id" => actual_client_id = Some(value.into_owned()),
-                            "client_secret" => actual_client_secret = Some(value.into_owned()),
-                            "grant_type" => actual_grant_type = Some(value.into_owned()),
-                            "redirect_uri" => actual_redirect_uri = Some(value.into_owned()),
-                            _ => continue,
-                        }
-                    }
-
-                    assert_eq!(Some(expected_auth_code_clone), actual_code);
-                    assert_eq!(Some(expected_client_id_clone), actual_client_id);
-                    assert_eq!(Some(expected_client_secret_clone), actual_client_secret);
-                    assert_eq!(Some(String::from("authorization_code")), actual_grant_type);
-                    let expected_redirect_uri = format!("http://localhost:{}", bot_port);
-                    assert_eq!(Some(expected_redirect_uri), actual_redirect_uri);
-
-                    let response = Response::from_string(
-                        serde_json::to_string(&expected_first_token_clone).unwrap(),
-                    );
-                    rq.respond(response).unwrap();
-                }
-                Err(e) => {
-                    println!("Error: {:?}", e);
-                }
-            };
-        });
-
-        let first_token = hook.obtain_first_token_impl(
-            expected_auth_code.clone(),
-            format!("http://localhost:{}", server_port),
-        );
-        assert_eq!(first_token, expected_first_token);
     }
 }


### PR DESCRIPTION
Use twitch_oauth2 logic to obtain the token. The library implements the oauth2 standard properly.

We still kept the logic for receiving the authorization code (phase 2 of the authentication flow), which we can also re-use in other projects if needed. 
